### PR TITLE
got rid of warning message due to harmless numpy/cython issues

### DIFF
--- a/supereeg/__init__.py
+++ b/supereeg/__init__.py
@@ -1,3 +1,8 @@
+#deal with numpy import warnings due to cython (https://stackoverflow.com/questions/40845304/runtimewarning-numpy-dtype-size-changed-may-indicate-binary-incompatibility)
+import warnings
+warnings.filterwarnings("ignore", message="numpy.dtype size changed")
+warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
+
 from .brain import Brain
 from .model import Model
 from .nifti import Nifti


### PR DESCRIPTION
This pull request addresses https://github.com/ContextLab/supereeg/issues/175