### PR TITLE
Fixing nii -> bo -> nii conversion; dropping support for python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
 - conda update -q conda
 - conda info -a
 - conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION pip pytest numpy pandas
-  scipy matplotlib seaborn scikit-learn numba
+  scipy matplotlib seaborn scikit-learn numba scikit-image
 - source activate testenv
 - conda install pytables
 - pip install Cython --install-option="--no-cython-compile"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ apt_packages:
   - liblzo2-dev
 
 install:
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi
+- if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+        wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+  else
+        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+  fi
 - bash miniconda.sh -b -p $HOME/miniconda
 - export PATH="$HOME/miniconda/bin:$PATH"
 - hash -r

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,20 @@ python:
 - '2.7'
 - '3.5'
 - '3.6'
+- '3.7'
+- '3.8'
 addons:
 apt_packages:
   - libbz2-dev
   - libhdf5-serial-dev
   - liblzo2-dev
-#allows for python3.7 testing in travis ci
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial
-      sudo: true
 
 install:
-- wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
 - bash miniconda.sh -b -p $HOME/miniconda
 - export PATH="$HOME/miniconda/bin:$PATH"
 - hash -r
@@ -30,6 +30,6 @@ install:
 - conda install pytables
 - pip install Cython --install-option="--no-cython-compile"
 - pip install .
-script: py.test
+script: pytest
 notifications:
   slack: context-lab:gLtt8NuYpyBW0ZkmwMJGtZut

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 sudo: false
 python:
-- '2.7'
 - '3.5'
 - '3.6'
 - '3.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,7 @@ apt_packages:
   - liblzo2-dev
 
 install:
-- if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-        wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
-  else
-        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-  fi
+- wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 - bash miniconda.sh -b -p $HOME/miniconda
 - export PATH="$HOME/miniconda/bin:$PATH"
 - hash -r

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To install the latest (bleeding edge) version directly from this repository use:
 <h3>GPU acceleration</h3>
 
 This is *highly* recommended if you are building your own models. Only NVIDIA GPUs are supported.
-To enable GPU acceleration for building models, pass `gpu=True` to `se.Model`, and install [CuPy](https://docs-cupy.chainer.org/en/stable/install.html). 
+To enable GPU acceleration for building models, pass `gpu=True` to `se.Model`, and install [CuPy](https://docs-cupy.chainer.org/en/stable/install.html).
 
 <h3>One time setup</h3>
 
@@ -40,7 +40,7 @@ To enable GPU acceleration for building models, pass `gpu=True` to `se.Model`, a
     - [Ubuntu](https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/)
     - [Debian](https://docs.docker.com/engine/installation/linux/docker-ce/debian/)
 2. Launch Docker and adjust the preferences to allocate sufficient resources (e.g. > 4GB RAM)
-3. Build the docker image by opening a terminal in the desired folder and enter `docker pull contextualdynamicslab/supereeg`  
+3. Build the docker image by opening a terminal in the desired folder and enter `docker pull contextualdynamicslab/supereeg`
 4. Use the image to create a new container for the workshop
     - The command below will create a new container that will map your computer's `Desktop` to `/mnt` within the container, so that location is shared between your host OS and the container. Feel free to change `Desktop` to whatever folder you prefer to share instead, but make sure to provide the full path. The command will also share port `8888` with your host computer so any jupyter notebooks launched from *within* the container will be accessible at `localhost:8888` in your web browser (or `192.168.99.100:8888` if using Docker Toolbox)
     - `docker run -it -p 8888:8888 --name supereeg -v ~/Desktop:/mnt contextualdynamicslab/supereeg `
@@ -61,7 +61,7 @@ To enable GPU acceleration for building models, pass `gpu=True` to `se.Model`, a
 The toolbox is currently supported on Mac and Linux.  It has not been tested on Windows (and we expect key functionality not to work properly on Windows systems). If using Windows, consider using Windows Subsystem for Linux or a Docker container.
 
 Dependencies:
-+ python 2.7, 3.5+
++ python 3.5+
 + pandas>=0.21.1
 + seaborn>=0.7.1
 + matplotlib==2.1.0
@@ -132,10 +132,6 @@ The preferred way to contribute to supereeg is to fork the main repository on Gi
 
 <h2>Testing</h2>
 
-<!-- [![Build Status](https://travis-ci.com/ContextLab/quail.svg?token=hxjzzuVkr2GZrDkPGN5n&branch=master) -->
+[![Build Status](https://travis-ci.org/ContextLab/supereeg.svg?branch=master)](https://travis-ci.org/ContextLab/supereeg)
 
-To test supereeg, install pytest (`pip install pytest`) and run `pytest` in the supereeg folder
-
-<!-- <h2>Examples</h2> -->
-
-<!-- See [here](http://cdl-quail.readthedocs.io/en/latest/auto_examples/index.html) for more examples. -->
+To test supereeg, install pytest (`pip install pytest`) and run `pytest` in the supereeg folder.

--- a/supereeg/helpers.py
+++ b/supereeg/helpers.py
@@ -370,7 +370,7 @@ def _blur_corrmat_cupy(Z, Zp, weights, block_size=1024):
     import cupy as cp
     from .kernel import blur
 
-    blur = f'#define BLOCKSIZE {block_size}' + blur
+    blur = '#define BLOCKSIZE {0}'.format(block_size) + blur
     blur_gpu = cp.RawKernel(blur, 'blur')
     get_maxes = cp.RawKernel(blur, 'arrmax')
     integrated = cp.RawKernel(blur, 'integrated')
@@ -1650,7 +1650,7 @@ def _brain_to_nifti(bo, nii_template, antialiasing=False): #FIXME: this is incre
 
     if bo.nifti_shape is not None:
         data = data.reshape(-1, order='F').reshape(data.shape)
- 
+
     nii = Nifti(data, affine=S)
     nii.header['descrip'] = 'from .bo'
     return nii

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -240,11 +240,11 @@ def test_brain_to_nifti():
 
 def test_bo_nii_bo():
     nii = _brain_to_nifti(bo, _gray(20))
+    print(type(str(nii.header['descrip'])))
     b_d, b_l, b_h, affine =_nifti_to_brain(nii)
     assert np.allclose(bo.get_locs(), b_l)
 
 def test_nii_bo_nii():
-
     bo_nii = se.Brain(_gray(20))
     nii = _brain_to_nifti(bo_nii, _gray(20))
     nii_0 = _gray(20).get_data().flatten()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -203,6 +203,7 @@ def test_model_subtract():
         assert True == True
 
 def test_cpu_vs_gpu_single_subject():
+    cupy = pytest.importorskip("cupy")
     locs = np.random.randn(25, 3)
     bo1 = se.simulate_bo(n_samples=512*30, locs=locs, sample_rate=512)
     bo2 = se.simulate_bo(n_samples=512*30, locs=locs, sample_rate=512)
@@ -218,6 +219,7 @@ def test_cpu_vs_gpu_single_subject():
     assert np.allclose(mo_cpu.get_model(), mo_gpu.get_model())
 
 def test_cpu_vs_gpu_mult_subject():
+    cupy = pytest.importorskip("cupy")
     locs1 = np.random.randn(25, 3)
     bo1a = se.simulate_bo(n_samples=512*30, locs=locs1, sample_rate=512)
     bo1b = se.simulate_bo(n_samples=512*30, locs=locs1, sample_rate=512)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -60,6 +60,7 @@ def test_model_predict():
     assert isinstance(bo, se.Brain)
 
 def test_model_gpu_predict():
+    cupy = pytest.importorskip("cupy")
     cpu_model = se.Model(data=data[0:2], locs=locs)
     cpu_bo = cpu_model.predict(data[3], nearest_neighbor=False)
     gpu_model = se.Model(data=data[0:2], locs=locs, gpu=True)


### PR DESCRIPTION
In order to get nii -> bo -> nii and bo -> nii -> bo conversions both working, added a `from .bo` flag in the Nifti header's `descrip` to be able to handle both cases. Am still not sure why this is necessary, since all of the affine transformations check out.

Also dropped support for 2.7 in both the readme and the Travis tests; skipping all GPU tests when there is no GPU or `CuPy` available.